### PR TITLE
DGC-172 - positioning and visibility of small nav logo

### DIFF
--- a/docroot/themes/custom/twentyseventeen/sass/base/icons/_icons.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/base/icons/_icons.scss
@@ -21,6 +21,6 @@
 
 svg.icon {
 	position: relative;
-	top: 0.5em;
+	top: 0.3em;
 	left: 0em;
 }

--- a/docroot/themes/custom/twentyseventeen/sass/components/nav/_nav.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/nav/_nav.scss
@@ -21,12 +21,24 @@
 
   &__logo {
     position: absolute;
-    top: 13px;
-    left: 10px;
+    top: 0;
+    left: 0;
+
+    @include breakpoint($min-tablet) {
+      display: none;
+    }
 
     svg {
       fill: $wht;
       transition: opacity 0.5s ease;
+      width: 40px;
+      height: 40px;
+    }
+
+    a {
+      display: block;
+      height: 55px;
+      padding: 0 15px;
     }
 
     a:hover svg {


### PR DESCRIPTION
Small nav logo
- better positioning
- make slightly larger
- larger link target area
- hide on desktop

#172 