### PR TITLE
[dgc-322] Add ‘General User’ text format for session submissions etc

### DIFF
--- a/config/default/editor.editor.general_user.yml
+++ b/config/default/editor.editor.general_user.yml
@@ -1,0 +1,48 @@
+uuid: 7f5a92a4-27a4-423f-a448-bb192a001074
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.general_user
+  module:
+    - ckeditor
+format: general_user
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Underline
+            - Bold
+            - Blockquote
+            - Italic
+        -
+          name: Links
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Lists
+          items:
+            - BulletedList
+            - NumberedList
+        -
+          name: Tools
+          items:
+            - PasteText
+  plugins:
+    language:
+      language_list: un
+    stylescombo:
+      styles: ''
+image_upload:
+  status: false
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: null
+    height: null

--- a/config/default/filter.format.general_user.yml
+++ b/config/default/filter.format.general_user.yml
@@ -1,0 +1,36 @@
+uuid: 95f7dadf-faa1-4e2a-a906-adbf313452b0
+langcode: en
+status: true
+dependencies: {  }
+name: 'General User'
+format: general_user
+weight: 0
+filters:
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type=''1 A I''> <li> <dl> <dt> <dd> <h2 id=''jump-*''> <h3 id> <h4 id> <h5 id> <h6 id>'
+      filter_html_help: true
+      filter_html_nofollow: false
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: 10
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: true
+    weight: 0
+    settings:
+      filter_url_length: 72

--- a/config/default/user.role.authenticated.yml
+++ b/config/default/user.role.authenticated.yml
@@ -15,3 +15,4 @@ permissions:
   - 'access site-wide contact form'
   - 'create session content'
   - 'edit own session content'
+  - 'use text format general_user'


### PR DESCRIPTION
Add a new text format for 'General User' with limited options. Authenticated users have perms to use this. 