### PR TITLE
Reorder experience level options on session from alpha to logical.

### DIFF
--- a/config/default/field.storage.node.field_experience_level.yml
+++ b/config/default/field.storage.node.field_experience_level.yml
@@ -14,14 +14,14 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: advanced
-      label: Advanced
-    -
       value: beginner
       label: Beginner
     -
       value: intermediate
       label: Intermediate
+    -
+      value: advanced
+      label: Advanced
   allowed_values_function: ''
 module: options
 locked: false


### PR DESCRIPTION
Fixes Drupal4Gov/Drupal-GovCon-2017#281