### PR TITLE
Fixed teaser view mode to output sponsor url as separate link and url.

### DIFF
--- a/config/default/core.entity_view_display.node.sponsor.default.yml
+++ b/config/default/core.entity_view_display.node.sponsor.default.yml
@@ -27,30 +27,30 @@ bundle: sponsor
 mode: default
 content:
   field_sponsor_logo:
-    weight: 103
-    label: above
+    weight: 0
+    label: hidden
     settings:
       image_style: ''
       image_link: ''
     third_party_settings: {  }
     type: image
   field_sponsor_related_attendees:
-    weight: 105
+    weight: 3
     label: above
     settings:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
   field_sponsor_sponsorship_level:
-    weight: 104
+    weight: 2
     label: above
     settings:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
   field_sponsor_url:
-    weight: 102
-    label: above
+    weight: 1
+    label: hidden
     settings:
       trim_length: 80
       target: _blank
@@ -60,7 +60,7 @@ content:
     third_party_settings: {  }
     type: link
   links:
-    weight: 100
+    weight: 4
     settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/default/core.entity_view_display.node.sponsor.teaser.yml
+++ b/config/default/core.entity_view_display.node.sponsor.teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - node.type.sponsor
   module:
     - image
+    - link
     - panelizer
     - user
 third_party_settings:
@@ -28,17 +29,24 @@ mode: teaser
 content:
   field_sponsor_logo:
     type: image
-    weight: 2
+    weight: 1
     label: hidden
     settings:
       image_style: ''
       image_link: ''
     third_party_settings: {  }
-  links:
+  field_sponsor_url:
+    type: link_separate
     weight: 0
-    settings: {  }
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: true
+      url_plain: false
+      rel: '0'
+      target: '0'
     third_party_settings: {  }
 hidden:
   field_sponsor_related_attendees: true
   field_sponsor_sponsorship_level: true
-  field_sponsor_url: true
+  links: true


### PR DESCRIPTION
This allowed the existing twig templates to start working again
to display the url_title (doesn't make a lot of sense) in the link href.

Also tweaked default view mode to put sponsor logo first, link second
and also hide link field label, sponsorship level third and links last.

Fixes Drupal4Gov/Drupal-GovCon-2017#363