### PR TITLE
DGC 384 Add News Updates

### DIFF
--- a/box/config.yml
+++ b/box/config.yml
@@ -8,6 +8,9 @@ vagrant_box: geerlingguy/ubuntu1404
 # Set drupal_site_name to the project's human-readable name.
 drupal_site_name: "Drupal GovCon"
 
+# Set the Drush Version
+drush_version: "8.x"
+
 # Provide the path to the project root to Vagrant.
 vagrant_synced_folders:
   # Set the local_path for the first synced folder to `.`.

--- a/docroot/themes/custom/twentyseventeen/images/GovCon-AlertIcon-Rev.svg
+++ b/docroot/themes/custom/twentyseventeen/images/GovCon-AlertIcon-Rev.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="_x39_x12_Alert_Icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+	 x="0px" y="0px" viewBox="0 0 108 108" style="enable-background:new 0 0 108 108;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<g>
+	<path class="st0" d="M54,0L0,108h108L54,0z M54,20.1L93.4,99H14.6L54,20.1z"/>
+	<polygon class="st0" points="45,45 45,72 54,81 63,72 63,45 	"/>
+	<polygon class="st0" points="45,94.5 63,94.5 54,85.5 	"/>
+</g>
+</svg>

--- a/docroot/themes/custom/twentyseventeen/images/GovCon-AlertIcon-SM-Rev.svg
+++ b/docroot/themes/custom/twentyseventeen/images/GovCon-AlertIcon-SM-Rev.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="_x39_x12_Alert_Icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+	 x="0px" y="0px" viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<g>
+	<path class="st0" d="M8,0L0,16h16L8,0z M8,3l5.8,11.7H2.2L8,3z"/>
+	<polygon class="st0" points="6.7,6.7 6.7,10.7 8,12 9.3,10.7 9.3,6.7 	"/>
+	<polygon class="st0" points="6.7,14 9.3,14 8,12.7 	"/>
+</g>
+</svg>

--- a/docroot/themes/custom/twentyseventeen/images/svg-sprite/images.svg
+++ b/docroot/themes/custom/twentyseventeen/images/svg-sprite/images.svg
@@ -1,4 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><symbol id="GovCon-DownArrow-SM-Rev" viewBox="0 0 14 14">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><symbol id="GovCon-AlertIcon-Rev" viewBox="0 0 108 108">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<g>
+	<path class="st0" d="M54,0L0,108h108L54,0z M54,20.1L93.4,99H14.6L54,20.1z"/>
+	<polygon class="st0" points="45,45 45,72 54,81 63,72 63,45 	"/>
+	<polygon class="st0" points="45,94.5 63,94.5 54,85.5 	"/>
+</g>
+</symbol><symbol id="GovCon-AlertIcon-SM-Rev" viewBox="0 0 16 16">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<g>
+	<path class="st0" d="M8,0L0,16h16L8,0z M8,3l5.8,11.7H2.2L8,3z"/>
+	<polygon class="st0" points="6.7,6.7 6.7,10.7 8,12 9.3,10.7 9.3,6.7 	"/>
+	<polygon class="st0" points="6.7,14 9.3,14 8,12.7 	"/>
+</g>
+</symbol><symbol id="GovCon-DownArrow-SM-Rev" viewBox="0 0 14 14">
 <polygon fill="#FFFFFF" points="9.3,7 9.3,0 4.7,0 4.7,7 0,7 7,14 14,7 "/>
 </symbol><symbol id="GovCon-FileUpload-SM-Rev" viewBox="0 0 14 14">
 <style type="text/css">

--- a/docroot/themes/custom/twentyseventeen/sass/components/critical-annoucements/_criticalannouncements.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/critical-annoucements/_criticalannouncements.scss
@@ -13,11 +13,13 @@
 }
 
 .critical-announcements p {
-	font-size: 1.5em;
+	font-size: 1.25em;
 	color: $wht;
 	margin: 0;
 	background: url('/themes/custom/twentyseventeen/images/GovCon-AlertIcon-SM-Rev.svg') 0% center no-repeat;
-	padding-left: 1.5em;
+	background-size: 1.25em;
+	width: 100%;
+	padding-left: 2em;
 	padding-top: 0.25em;
 	
 }
@@ -33,7 +35,8 @@
 }
 
     @include breakpoint($min-tablet) {
-    	.critical-announcements {
-    		color: #0f0;
+    	.critical-announcements p {
+    		max-width: 80em;
+    		margin: 0 auto;
     	}
   }

--- a/docroot/themes/custom/twentyseventeen/sass/components/critical-annoucements/_criticalannouncements.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/critical-annoucements/_criticalannouncements.scss
@@ -1,0 +1,39 @@
+// Critical Announcements
+//
+// Critical announcements to be run in the header.
+//
+// Markup: criticalannouncements.twig
+//
+// Style guide: components.criticalannouncements
+
+.critical-announcements {
+	background: rgba(96,12,12,1);
+	padding: 1em;
+	margin: 0;
+}
+
+.critical-announcements p {
+	font-size: 1.5em;
+	color: $wht;
+	margin: 0;
+	background: url('/themes/custom/twentyseventeen/images/GovCon-AlertIcon-SM-Rev.svg') 0% center no-repeat;
+	padding-left: 1.5em;
+	padding-top: 0.25em;
+	
+}
+
+.critical-announcements a:link,
+.critical-announcements a:visited {
+	color: rgba($wht, 0.5);
+	text-decoration: none;
+}
+
+.critical-announcements a:hover {
+	color: rgba($wht, 1);
+}
+
+    @include breakpoint($min-tablet) {
+    	.critical-announcements {
+    		color: #0f0;
+    	}
+  }

--- a/docroot/themes/custom/twentyseventeen/sass/components/critical-annoucements/criticalannouncements.json
+++ b/docroot/themes/custom/twentyseventeen/sass/components/critical-annoucements/criticalannouncements.json
@@ -1,0 +1,3 @@
+{
+  "body": "This is a critical annoumcent. More information can be found <a href='#'>here</a>."
+}

--- a/docroot/themes/custom/twentyseventeen/sass/components/critical-annoucements/criticalannouncements.json
+++ b/docroot/themes/custom/twentyseventeen/sass/components/critical-annoucements/criticalannouncements.json
@@ -1,3 +1,3 @@
 {
-  "body": "This is a critical annoumcent. More information can be found <a href='#'>here</a>."
+  "body": "This is a critical announcement. More information can be found <a href='#'>here</a>."
 }

--- a/docroot/themes/custom/twentyseventeen/sass/components/critical-annoucements/criticalannouncements.twig
+++ b/docroot/themes/custom/twentyseventeen/sass/components/critical-annoucements/criticalannouncements.twig
@@ -1,0 +1,10 @@
+<div class="critical-announcements">
+	<div class="views-row">
+		<div class="views-field-title">
+			<h2>{{title}}</h2>
+		</div>
+		<div class="views-field-body">
+			<p>{{body}}</p>
+		</div>
+	</div> <!-- End views-row -->
+</div>

--- a/docroot/themes/custom/twentyseventeen/sass/components/home-annoucements/_homeannouncements.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/home-annoucements/_homeannouncements.scss
@@ -1,0 +1,46 @@
+// Home Announcements
+//
+// Special Announcements to be run on homepage.
+//
+// Markup: homeannouncements.twig
+//
+// Style guide: components.homeannouncements
+
+.home-announcements {
+	background: rgba($green, 0.2);
+	border-top: 4px solid $green;
+	padding: 1em;
+	margin: 1em 0 1em 0;
+}
+
+.home-announcements h2 {
+	font-weight: 700;
+	font-size: 1.5em;
+	color: $green;
+	padding-bottom: 0;
+	
+}
+
+.home-announcements p {
+	margin-bottom: 0.5em;
+}
+
+.home-announcements p:first-child {
+	margin-top: 0;
+}
+
+.home-announcements .views-row {
+	border-bottom: 2px solid $green;
+	margin-bottom: 1em;
+}
+
+.home-announcements .views-row:last-child {
+	border-bottom: none;
+	margin-bottom: 0;
+}
+
+    @include breakpoint($min-tablet) {
+    	.home-announcements {
+    		margin: 1em 10% 2em 10%;
+    	}
+  }

--- a/docroot/themes/custom/twentyseventeen/sass/components/home-annoucements/homeannouncements.json
+++ b/docroot/themes/custom/twentyseventeen/sass/components/home-annoucements/homeannouncements.json
@@ -1,0 +1,4 @@
+{
+  "title": "This is a Special Announcement",
+  "body": "This is an incredible special announcement, which you will forever regret not taking advantage of. Incredible amounts of good karma will be awarded to those who take advantage. More information can be found <a href='#'>here</a>."
+}

--- a/docroot/themes/custom/twentyseventeen/sass/components/home-annoucements/homeannouncements.twig
+++ b/docroot/themes/custom/twentyseventeen/sass/components/home-annoucements/homeannouncements.twig
@@ -1,0 +1,10 @@
+<div class="home-announcements">
+	<div class="views-row">
+		<div class="views-field-title">
+			<h2>{{title}}</h2>
+		</div>
+		<div class="views-field-body">
+			<p>{{body}}</p>
+		</div>
+	</div> <!-- End views-row -->
+</div>


### PR DESCRIPTION
New content type created, with two displays: general announcements (only display on homepage), and critical announcements (display on every page). To avoid outdated information being left on the site to confuse visitors, announcements automatically expire if left unchanged for 7 days.