### PR TITLE
DGC-478: Fix Sponsor Link

### DIFF
--- a/docroot/themes/custom/twentyseventeen/sass/components/nav/_nav.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/nav/_nav.scss
@@ -234,7 +234,7 @@
 
     ~ nav .nav__items--first-level {
       height: auto;
-      max-height: 60rem;
+      max-height: 90rem;
       transition: all 2s cubic-bezier(.5, 1, .22, 1);
     }
 


### PR DESCRIPTION
 Maximum height of mobile navigation area increased to account for additional level 1 elements. Without this fix, Sponsors will display on desktop and tablet, but not mobile.