### PR TITLE
dgc-507: Update closed Registration webform submission language

### DIFF
--- a/config/default/webform.webform.registration.yml
+++ b/config/default/webform.webform.registration.yml
@@ -68,7 +68,7 @@ settings:
   confirmation_back_label: ''
   confirmation_back_attributes: {  }
   limit_total: 1400
-  limit_total_message: 'Registration is currently closed due to the volume of already registered GovCon participants.&nbsp;'
+  limit_total_message: "<p>Thank you for your interest in Drupal GovCon. Unfortunately, we have sold out! Please check back - we have folks cancel their tickets as we get closer to the event.</p>\r\n\r\n<p>As users cancel their tickets, new tickets will be available on a first come - first served basis.</p>"
   limit_user: null
   limit_user_message: ''
   purge: none


### PR DESCRIPTION
Updated to: 

Thank you for your interest in Drupal GovCon. Unfortunately, we have sold out! Please check back - we have folks cancel their tickets as we get closer to the event.

As users cancel their tickets, new tickets will be available on a first come - first served basis.