### PR TITLE
DGC-542: Add Role Displays

### DIFF
--- a/config/default/block.block.dgcintro.yml
+++ b/config/default/block.block.dgcintro.yml
@@ -10,7 +10,7 @@ dependencies:
 id: dgcintro
 theme: twentyseventeen
 region: content
-weight: -10
+weight: -11
 provider: null
 plugin: dgc_intro
 settings:

--- a/config/default/block.block.dgcsecondarybanners.yml
+++ b/config/default/block.block.dgcsecondarybanners.yml
@@ -10,7 +10,7 @@ dependencies:
 id: dgcsecondarybanners
 theme: twentyseventeen
 region: content
-weight: -4
+weight: -5
 provider: null
 plugin: dgc_secondarybanners
 settings:

--- a/config/default/block.block.exposedformsessions_schedulepage_1.yml
+++ b/config/default/block.block.exposedformsessions_schedulepage_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: exposedformsessions_schedulepage_1
 theme: twentyseventeen
 region: content
-weight: -8
+weight: -9
 provider: null
 plugin: 'views_exposed_filter_block:sessions_schedule-page_1'
 settings:

--- a/config/default/block.block.schedule.yml
+++ b/config/default/block.block.schedule.yml
@@ -11,7 +11,7 @@ dependencies:
 id: schedule
 theme: twentyseventeen
 region: content
-weight: -7
+weight: -8
 provider: null
 plugin: 'system_menu_block:schedule'
 settings:

--- a/config/default/block.block.sessionclose.yml
+++ b/config/default/block.block.sessionclose.yml
@@ -12,7 +12,7 @@ dependencies:
 id: sessionclose
 theme: twentyseventeen
 region: content
-weight: -10
+weight: 1
 provider: null
 plugin: 'block_content:d428d002-c8df-43b4-8b27-45824dc65782'
 settings:

--- a/config/default/block.block.twentyseventeen_content.yml
+++ b/config/default/block.block.twentyseventeen_content.yml
@@ -11,7 +11,7 @@ _core:
 id: twentyseventeen_content
 theme: twentyseventeen
 region: content
-weight: -3
+weight: -4
 provider: null
 plugin: system_main_block
 settings:

--- a/config/default/block.block.twentyseventeen_help.yml
+++ b/config/default/block.block.twentyseventeen_help.yml
@@ -11,7 +11,7 @@ _core:
 id: twentyseventeen_help
 theme: twentyseventeen
 region: content
-weight: -12
+weight: -13
 provider: null
 plugin: help_block
 settings:

--- a/config/default/block.block.twentyseventeen_local_actions.yml
+++ b/config/default/block.block.twentyseventeen_local_actions.yml
@@ -9,7 +9,7 @@ _core:
 id: twentyseventeen_local_actions
 theme: twentyseventeen
 region: content
-weight: -11
+weight: -12
 provider: null
 plugin: local_actions_block
 settings:

--- a/config/default/block.block.twentyseventeen_local_tasks.yml
+++ b/config/default/block.block.twentyseventeen_local_tasks.yml
@@ -9,7 +9,7 @@ _core:
 id: twentyseventeen_local_tasks
 theme: twentyseventeen
 region: content
-weight: -9
+weight: -10
 provider: null
 plugin: local_tasks_block
 settings:

--- a/config/default/block.block.twentyseventeen_page_title.yml
+++ b/config/default/block.block.twentyseventeen_page_title.yml
@@ -11,7 +11,7 @@ _core:
 id: twentyseventeen_page_title
 theme: twentyseventeen
 region: content
-weight: -13
+weight: -14
 provider: null
 plugin: page_title_block
 settings:

--- a/config/default/block.block.user_registrations.yml
+++ b/config/default/block.block.user_registrations.yml
@@ -12,7 +12,7 @@ dependencies:
 id: user_registrations
 theme: twentyseventeen
 region: content
-weight: -2
+weight: -3
 provider: null
 plugin: 'views_block:user_registrations-block_1'
 settings:

--- a/config/default/block.block.views_block__my_sessions_schedule_block_1.yml
+++ b/config/default/block.block.views_block__my_sessions_schedule_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__my_sessions_schedule_block_1
 theme: twentyseventeen
 region: content
-weight: 0
+weight: -2
 provider: null
 plugin: 'views_block:my_sessions_schedule-block_1'
 settings:

--- a/config/default/block.block.views_block__presenters_block_1.yml
+++ b/config/default/block.block.views_block__presenters_block_1.yml
@@ -13,7 +13,7 @@ dependencies:
 id: views_block__presenters_block_1
 theme: twentyseventeen
 region: content
-weight: -6
+weight: -7
 provider: null
 plugin: 'views_block:presenters-block_1'
 settings:

--- a/config/default/block.block.views_block__session_flag_link_block_1.yml
+++ b/config/default/block.block.views_block__session_flag_link_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__session_flag_link_block_1
 theme: twentyseventeen
 region: content
-weight: 1
+weight: 0
 provider: null
 plugin: 'views_block:session_flag_link-block_1'
 settings:

--- a/config/default/block.block.views_block__special_announcements_display_block_1.yml
+++ b/config/default/block.block.views_block__special_announcements_display_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__special_announcements_display_block_1
 theme: twentyseventeen
 region: content
-weight: -5
+weight: -6
 provider: null
 plugin: 'views_block:special_announcements_display-block_1'
 settings:

--- a/config/default/block.block.views_block__user_sessions_user_sessions_block.yml
+++ b/config/default/block.block.views_block__user_sessions_user_sessions_block.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__user_sessions_user_sessions_block
 theme: twentyseventeen
 region: content
-weight: 0
+weight: -1
 provider: null
 plugin: 'views_block:user_sessions-user_sessions_block'
 settings:

--- a/config/default/core.entity_form_display.user.user.default.yml
+++ b/config/default/core.entity_form_display.user.user.default.yml
@@ -3,20 +3,22 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.image_browser
     - field.field.user.user.field_bio
     - field.field.user.user.field_company
+    - field.field.user.user.field_conference_role
     - field.field.user.user.field_drupal_org_link
     - field.field.user.user.field_drupal_org_username
     - field.field.user.user.field_first_name
     - field.field.user.user.field_job_title
     - field.field.user.user.field_last_name
+    - field.field.user.user.field_picture
     - field.field.user.user.field_public_e_mail
     - field.field.user.user.field_twitter_account
     - field.field.user.user.field_user_picture
     - field.field.user.user.field_website
-    - image.style.thumbnail
   module:
-    - image
+    - entity_browser
     - link
     - path
     - text
@@ -47,6 +49,12 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_conference_role:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   field_drupal_org_link:
     weight: 15
     settings:
@@ -64,7 +72,7 @@ content:
     type: string_textfield
     region: content
   field_first_name:
-    weight: 2
+    weight: 3
     settings:
       size: 60
       placeholder: ''
@@ -80,7 +88,7 @@ content:
     type: string_textfield
     region: content
   field_last_name:
-    weight: 3
+    weight: 4
     settings:
       size: 60
       placeholder: ''
@@ -105,7 +113,7 @@ content:
     region: content
   field_user_picture:
     type: entity_browser_file
-    weight: 1
+    weight: 2
     settings:
       entity_browser: image_browser
       field_widget_edit: true
@@ -115,6 +123,7 @@ content:
       open: true
       selection_mode: selection_append
     third_party_settings: {  }
+    region: content
   field_website:
     weight: 14
     settings:

--- a/config/default/core.entity_form_display.user.user.default.yml
+++ b/config/default/core.entity_form_display.user.user.default.yml
@@ -58,8 +58,8 @@ content:
   field_drupal_org_link:
     weight: 15
     settings:
-      placeholder_url: ''
-      placeholder_title: ''
+      placeholder_url: 'https://www.drupal.org/u/[your username]'
+      placeholder_title: 'https://www.drupal.org/u/[your username]'
     third_party_settings: {  }
     type: link_default
     region: content
@@ -98,16 +98,16 @@ content:
   field_public_e_mail:
     weight: 16
     settings:
-      placeholder_url: ''
-      placeholder_title: ''
+      placeholder_url: 'mailto:address@example.com'
+      placeholder_title: 'mailto:address@example.com'
     third_party_settings: {  }
     type: link_default
     region: content
   field_twitter_account:
     weight: 13
     settings:
-      placeholder_url: ''
-      placeholder_title: ''
+      placeholder_url: 'http://twitter.com/[your username]'
+      placeholder_title: 'http://twitter.com/[your username]'
     third_party_settings: {  }
     type: link_default
     region: content
@@ -127,8 +127,8 @@ content:
   field_website:
     weight: 14
     settings:
-      placeholder_url: ''
-      placeholder_title: ''
+      placeholder_url: 'http://example.com'
+      placeholder_title: 'http://example.com'
     third_party_settings: {  }
     type: link_default
     region: content

--- a/config/default/core.entity_view_display.user.user.default.yml
+++ b/config/default/core.entity_view_display.user.user.default.yml
@@ -5,11 +5,13 @@ dependencies:
   config:
     - field.field.user.user.field_bio
     - field.field.user.user.field_company
+    - field.field.user.user.field_conference_role
     - field.field.user.user.field_drupal_org_link
     - field.field.user.user.field_drupal_org_username
     - field.field.user.user.field_first_name
     - field.field.user.user.field_job_title
     - field.field.user.user.field_last_name
+    - field.field.user.user.field_picture
     - field.field.user.user.field_public_e_mail
     - field.field.user.user.field_twitter_account
     - field.field.user.user.field_user_picture
@@ -46,6 +48,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_conference_role:
+    weight: 12
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_drupal_org_link:
     weight: 10

--- a/config/default/field.field.user.user.field_conference_role.yml
+++ b/config/default/field.field.user.user.field_conference_role.yml
@@ -1,0 +1,29 @@
+uuid: bf4f011e-2187-4ff8-8eb1-e2e83312e53b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_conference_role
+    - taxonomy.vocabulary.conference_role
+  module:
+    - user
+id: user.user.field_conference_role
+field_name: field_conference_role
+entity_type: user
+bundle: user
+label: 'Conference Role'
+description: 'Add conference roles to a user. This is used for reporting, grouping, and displaying users based on role. An example is displaying all organizers for a given year.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      conference_role: conference_role
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.user.user.field_public_e_mail.yml
+++ b/config/default/field.field.user.user.field_public_e_mail.yml
@@ -11,8 +11,8 @@ id: user.user.field_public_e_mail
 field_name: field_public_e_mail
 entity_type: user
 bundle: user
-label: 'Public E-Mail'
-description: 'Use to publicly display a contact e-mail to help with networking. Please enter in this pattern: mailto:[your e-mail address]'
+label: E-Mail
+description: 'Use to publicly display a contact e-mail to help with networking. Please enter in this pattern: mailto:address@example.com.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/default/field.storage.user.field_conference_role.yml
+++ b/config/default/field.storage.user.field_conference_role.yml
@@ -1,0 +1,24 @@
+uuid: f15c011b-0cbc-44da-83df-fea14f8b9d62
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - taxonomy
+    - user
+third_party_settings:
+  field_permissions:
+    permission_type: custom
+id: user.field_conference_role
+field_name: field_conference_role
+entity_type: user
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/taxonomy.vocabulary.conference_role.yml
+++ b/config/default/taxonomy.vocabulary.conference_role.yml
@@ -1,0 +1,9 @@
+uuid: d611bb6c-87d8-49b2-86de-5e4c51a07b8a
+langcode: en
+status: true
+dependencies: {  }
+name: 'Conference Role'
+vid: conference_role
+description: 'Roles served by GovCon community members.'
+hierarchy: 1
+weight: 0

--- a/config/default/views.view.attendee_displays.yml
+++ b/config/default/views.view.attendee_displays.yml
@@ -59,10 +59,10 @@ display:
         type: bef
         options:
           submit_button: Apply
-          reset_button: false
+          reset_button: true
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
+          expose_sort_order: false
           sort_asc_label: Asc
           sort_desc_label: Desc
           bef:
@@ -71,7 +71,19 @@ display:
               secondary_label: 'Advanced options'
               autosubmit: false
               autosubmit_hide: false
-            webform_submission_value_1:
+            field_first_name_value:
+              bef_format: default
+              more_options:
+                is_secondary: false
+                rewrite:
+                  filter_rewrite_values: ''
+            field_last_name_value:
+              bef_format: default
+              more_options:
+                is_secondary: false
+                rewrite:
+                  filter_rewrite_values: ''
+            field_company_value:
               bef_format: default
               more_options:
                 is_secondary: false
@@ -93,6 +105,72 @@ display:
           separator: ''
           hide_empty: false
       fields:
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: uid
+          plugin_id: field
         webform_submission_value:
           id: webform_submission_value
           table: webform_submission_field_registration_first_name
@@ -151,7 +229,7 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -194,7 +272,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -266,10 +344,10 @@ display:
           label: ''
           exclude: false
           alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
+            alter_text: true
+            text: '{{ field_first_name }} {{ field_last_name }}'
+            make_link: true
+            path: 'user/{{ uid }}'
             absolute: false
             external: false
             replace_spaces: false
@@ -307,7 +385,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -498,6 +576,12 @@ display:
           entity_type: webform_submission
           entity_field: sid
           plugin_id: field
+        field_user_picture:
+          id: field_user_picture
+          table: user__field_user_picture
+          field: field_user_picture
+          plugin_id: field
+          relationship: uid
       filters:
         webform_id:
           id: webform_id
@@ -608,6 +692,7 @@ display:
               landing_page_reviewer: '0'
               media_creator: '0'
               media_manager: '0'
+              volunteer: '0'
           is_grouped: false
           group_info:
             label: ''
@@ -653,6 +738,7 @@ display:
               landing_page_reviewer: '0'
               media_creator: '0'
               media_manager: '0'
+              volunteer: '0'
           is_grouped: false
           group_info:
             label: ''
@@ -698,6 +784,7 @@ display:
               landing_page_reviewer: '0'
               media_creator: '0'
               media_manager: '0'
+              volunteer: '0'
           is_grouped: false
           group_info:
             label: ''
@@ -798,6 +885,7 @@ display:
         - 'config:field.storage.user.field_company'
         - 'config:field.storage.user.field_first_name'
         - 'config:field.storage.user.field_last_name'
+        - 'config:field.storage.user.field_user_picture'
   page_1:
     display_plugin: page
     id: page_1
@@ -822,6 +910,8 @@ display:
       defaults:
         header: false
         pager: false
+        fields: false
+        empty: false
       display_description: ''
       menu:
         type: normal
@@ -853,6 +943,490 @@ display:
             offset: false
             offset_label: Offset
           quantity: 5
+      fields:
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: uid
+          plugin_id: field
+        webform_submission_value:
+          id: webform_submission_value
+          table: webform_submission_field_registration_first_name
+          field: webform_submission_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 140
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          webform_element_format: value
+          plugin_id: webform_submission_field
+        field_first_name:
+          id: field_first_name
+          table: user__field_first_name
+          field: field_first_name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 140
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        webform_submission_value_1:
+          id: webform_submission_value_1
+          table: webform_submission_field_registration_last_name
+          field: webform_submission_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          webform_element_format: value
+          plugin_id: webform_submission_field
+        field_last_name:
+          id: field_last_name
+          table: user__field_last_name
+          field: field_last_name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ field_first_name }} {{ field_last_name }}'
+            make_link: true
+            path: 'user/{{ uid }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 60
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        webform_submission_value_2:
+          id: webform_submission_value_2
+          table: webform_submission_field_registration_company_name
+          field: webform_submission_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 255
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          webform_element_format: value
+          plugin_id: webform_submission_field
+        field_company:
+          id: field_company
+          table: user__field_company
+          field: field_company
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 60
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        sid:
+          id: sid
+          table: webform_submission
+          field: sid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'Unfortunately, no results match your search criteria. You may try resetting the search form, and trying again.'
+          plugin_id: text_custom
     cache_metadata:
       max-age: -1
       contexts:
@@ -886,6 +1460,72 @@ display:
       path: get-involved/organizers
       css_class: 'attendee_display attendeepicture_display'
       fields:
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: uid
+          plugin_id: field
         field_user_picture:
           id: field_user_picture
           table: user__field_user_picture
@@ -1008,7 +1648,7 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -1051,7 +1691,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1123,10 +1763,10 @@ display:
           label: ''
           exclude: false
           alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
+            alter_text: true
+            text: '{{ field_first_name }} {{ field_last_name }}'
+            make_link: true
+            path: 'user/{{ uid }}'
             absolute: false
             external: false
             replace_spaces: false
@@ -1164,7 +1804,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1756,9 +2396,76 @@ display:
         arguments: false
         relationships: false
         pager: false
+        query: false
       path: program/presenters
       css_class: 'attendee_display attendeepicture_display'
       fields:
+        uid_1:
+          id: uid_1
+          table: users_field_data
+          field: uid
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: uid
+          plugin_id: field
         field_user_picture:
           id: field_user_picture
           table: user__field_user_picture
@@ -1881,7 +2588,7 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -1996,10 +2703,10 @@ display:
           label: ''
           exclude: false
           alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
+            alter_text: true
+            text: '{{ field_first_name }} {{ field_last_name }}'
+            make_link: true
+            path: 'user/{{ uid_1 }}'
             absolute: false
             external: false
             replace_spaces: false
@@ -2782,6 +3489,14 @@ display:
           views_infinite_scroll:
             button_text: 'Load More'
             automatically_load_content: true
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_comment: ''
+          query_tags: null
     cache_metadata:
       max-age: -1
       contexts:
@@ -2816,539 +3531,6 @@ display:
         pager: false
       path: get-involved/volunteers
       css_class: 'attendee_display attendeepicture_display'
-      fields:
-        field_user_picture:
-          id: field_user_picture
-          table: user__field_user_picture
-          field: field_user_picture
-          relationship: uid
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: '<img src="/themes/custom/twentyseventeen/images/GovCon2017_UserProfileImage.png" alt="Default Avatar">'
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: false
-          click_sort_column: target_id
-          type: image
-          settings:
-            image_style: user_profile_image
-            image_link: content
-          group_column: ''
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        webform_submission_value:
-          id: webform_submission_value
-          table: webform_submission_field_registration_first_name
-          field: webform_submission_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 140
-            word_boundary: false
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: true
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          webform_element_format: value
-          plugin_id: webform_submission_field
-        field_first_name:
-          id: field_first_name
-          table: user__field_first_name
-          field: field_first_name
-          relationship: uid
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 140
-            word_boundary: false
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        webform_submission_value_1:
-          id: webform_submission_value_1
-          table: webform_submission_field_registration_last_name
-          field: webform_submission_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          webform_element_format: value
-          plugin_id: webform_submission_field
-        field_last_name:
-          id: field_last_name
-          table: user__field_last_name
-          field: field_last_name
-          relationship: uid
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 60
-            word_boundary: false
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        webform_submission_value_2:
-          id: webform_submission_value_2
-          table: webform_submission_field_registration_company_name
-          field: webform_submission_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 255
-            word_boundary: false
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: true
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          webform_element_format: value
-          plugin_id: webform_submission_field
-        field_company:
-          id: field_company
-          table: user__field_company
-          field: field_company
-          relationship: uid
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 60
-            word_boundary: false
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        sid:
-          id: sid
-          table: webform_submission
-          field: sid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: number_integer
-          settings:
-            thousand_separator: ''
-            prefix_suffix: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
-        field_conference_role:
-          id: field_conference_role
-          table: user__field_conference_role
-          field: field_conference_role
-          relationship: uid
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_label
-          settings:
-            link: false
-          group_column: target_id
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
       filters:
         webform_id:
           id: webform_id
@@ -3675,6 +3857,542 @@ display:
           views_infinite_scroll:
             button_text: 'Load More'
             automatically_load_content: true
+      fields:
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: uid
+          plugin_id: field
+        field_user_picture:
+          id: field_user_picture
+          table: user__field_user_picture
+          field: field_user_picture
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: '<img src="/themes/custom/twentyseventeen/images/GovCon2017_UserProfileImage.png" alt="Default Avatar">'
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: user_profile_image
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        webform_submission_value:
+          id: webform_submission_value
+          table: webform_submission_field_registration_first_name
+          field: webform_submission_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 140
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          webform_element_format: value
+          plugin_id: webform_submission_field
+        field_first_name:
+          id: field_first_name
+          table: user__field_first_name
+          field: field_first_name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 140
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        webform_submission_value_1:
+          id: webform_submission_value_1
+          table: webform_submission_field_registration_last_name
+          field: webform_submission_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          webform_element_format: value
+          plugin_id: webform_submission_field
+        field_last_name:
+          id: field_last_name
+          table: user__field_last_name
+          field: field_last_name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ field_first_name }} {{ field_last_name }}'
+            make_link: true
+            path: 'user/{{ uid }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 60
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        webform_submission_value_2:
+          id: webform_submission_value_2
+          table: webform_submission_field_registration_company_name
+          field: webform_submission_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 255
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          webform_element_format: value
+          plugin_id: webform_submission_field
+        field_company:
+          id: field_company
+          table: user__field_company
+          field: field_company
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 60
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        sid:
+          id: sid
+          table: webform_submission
+          field: sid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
     cache_metadata:
       max-age: -1
       contexts:
@@ -3685,7 +4403,6 @@ display:
         - user
       tags:
         - 'config:field.storage.user.field_company'
-        - 'config:field.storage.user.field_conference_role'
         - 'config:field.storage.user.field_first_name'
         - 'config:field.storage.user.field_last_name'
         - 'config:field.storage.user.field_user_picture'

--- a/config/default/views.view.attendee_displays.yml
+++ b/config/default/views.view.attendee_displays.yml
@@ -15,8 +15,8 @@ dependencies:
     - taxonomy.vocabulary.conference_role
     - webform.webform.registration
   content:
-    - 'taxonomy_term:conference_role:25237e82-17da-4e06-8de8-d8dec11645c1'
-    - 'taxonomy_term:conference_role:56331631-f94f-422b-8143-7ba358c5f881'
+    - 'taxonomy_term:conference_role:0daf4b85-bb67-4c97-ab3a-fafd54c5a39a'
+    - 'taxonomy_term:conference_role:66fb0203-243d-498f-aa80-ecffd760592b'
   module:
     - better_exposed_filters
     - image
@@ -2280,7 +2280,7 @@ display:
           admin_label: ''
           operator: or
           value:
-            103: 103
+            106: 106
           group: 1
           exposed: false
           expose:
@@ -3753,7 +3753,7 @@ display:
           admin_label: ''
           operator: or
           value:
-            106: 106
+            109: 109
           group: 1
           exposed: false
           expose:

--- a/config/default/views.view.attendee_displays.yml
+++ b/config/default/views.view.attendee_displays.yml
@@ -5,18 +5,25 @@ dependencies:
   config:
     - field.storage.node.field_session_co_presenter_s_
     - field.storage.user.field_company
+    - field.storage.user.field_conference_role
     - field.storage.user.field_first_name
     - field.storage.user.field_last_name
     - field.storage.user.field_user_picture
     - image.style.user_profile_image
     - node.type.session
-    - user.role.administrator
+    - system.menu.main
+    - taxonomy.vocabulary.conference_role
     - webform.webform.registration
+  content:
+    - 'taxonomy_term:conference_role:25237e82-17da-4e06-8de8-d8dec11645c1'
+    - 'taxonomy_term:conference_role:56331631-f94f-422b-8143-7ba358c5f881'
   module:
     - better_exposed_filters
     - image
     - node
+    - taxonomy
     - user
+    - views_infinite_scroll
     - webform
     - webform_views
 id: attendee_displays
@@ -169,7 +176,7 @@ display:
             more_link_text: ''
             more_link_path: ''
             strip_tags: false
-            trim: true
+            trim: false
             preserve_tags: ''
             html: false
           element_type: ''
@@ -282,7 +289,7 @@ display:
             more_link_text: ''
             more_link_path: ''
             strip_tags: false
-            trim: true
+            trim: false
             preserve_tags: ''
             html: false
           element_type: ''
@@ -395,7 +402,7 @@ display:
             more_link_text: ''
             more_link_path: ''
             strip_tags: false
-            trim: true
+            trim: false
             preserve_tags: ''
             html: false
           element_type: ''
@@ -777,6 +784,9 @@ display:
           plugin_id: string
       display_extenders: {  }
       css_class: 'attendee_display attendee_names'
+      use_ajax: false
+      hide_attachment_summary: false
+      group_by: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -795,7 +805,7 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: attendees
+      path: get-involved/attendees
       exposed_block: false
       header:
         area_text_custom:
@@ -811,13 +821,45 @@ display:
           plugin_id: text_custom
       defaults:
         header: false
+        pager: false
       display_description: ''
+      menu:
+        type: normal
+        title: Attendees
+        description: ''
+        expanded: false
+        parent: 'menu_link_content:f0567892-778c-4181-bce3-a9f634ee5703'
+        weight: 4
+        context: '0'
+        menu_name: main
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹
+            next: ›
+            first: «
+            last: »
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 5
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - url.query_args
         - user
       tags:
         - 'config:field.storage.user.field_company'
@@ -840,7 +882,8 @@ display:
         filter_groups: false
         exposed_form: false
         header: false
-      path: organizers
+        group_by: true
+      path: get-involved/organizers
       css_class: 'attendee_display attendeepicture_display'
       fields:
         field_user_picture:
@@ -887,10 +930,10 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: '<img src="/themes/custom/twentyseventeen/images/GovCon2017_UserProfileImage.png" alt="Default Avatar">'
           hide_empty: false
           empty_zero: false
-          hide_alter_empty: true
+          hide_alter_empty: false
           click_sort_column: target_id
           type: image
           settings:
@@ -990,7 +1033,7 @@ display:
             more_link_text: ''
             more_link_path: ''
             strip_tags: false
-            trim: true
+            trim: false
             preserve_tags: ''
             html: false
           element_type: ''
@@ -1103,7 +1146,7 @@ display:
             more_link_text: ''
             more_link_path: ''
             strip_tags: false
-            trim: true
+            trim: false
             preserve_tags: ''
             html: false
           element_type: ''
@@ -1216,7 +1259,7 @@ display:
             more_link_text: ''
             more_link_path: ''
             strip_tags: false
-            trim: true
+            trim: false
             preserve_tags: ''
             html: false
           element_type: ''
@@ -1311,6 +1354,69 @@ display:
           field_api_classes: false
           entity_type: webform_submission
           entity_field: sid
+          plugin_id: field
+        field_conference_role:
+          id: field_conference_role
+          table: user__field_conference_role
+          field: field_conference_role
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
           plugin_id: field
       filters:
         webform_id:
@@ -1525,16 +1631,16 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: string
-        roles_target_id:
-          id: roles_target_id
-          table: user__roles
-          field: roles_target_id
+        field_conference_role_target_id:
+          id: field_conference_role_target_id
+          table: user__field_conference_role
+          field: field_conference_role_target_id
           relationship: uid
           group_type: group
           admin_label: ''
           operator: or
           value:
-            administrator: administrator
+            103: 103
           group: 1
           exposed: false
           expose:
@@ -1563,8 +1669,12 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          entity_type: user
-          plugin_id: user_roles
+          type: select
+          limit: true
+          vid: conference_role
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
@@ -1602,8 +1712,17 @@ display:
           admin_label: ''
           empty: false
           tokenize: false
-          content: 'Here''s the volunteer team that made Drupal GovCon happen. Interested in joining to help out? Volunteers are always <a href="/contact">welcome</a>.'
+          content: 'Here''s the organization and planning team that made Drupal GovCon happen. Interested in joining to help out? New partners are always <a href="/contact">welcome</a>.'
           plugin_id: text_custom
+      menu:
+        type: normal
+        title: Organizers
+        description: ''
+        expanded: false
+        parent: 'menu_link_content:f0567892-778c-4181-bce3-a9f634ee5703'
+        weight: 5
+        context: '0'
+        menu_name: main
     cache_metadata:
       max-age: -1
       contexts:
@@ -1613,6 +1732,7 @@ display:
         - user
       tags:
         - 'config:field.storage.user.field_company'
+        - 'config:field.storage.user.field_conference_role'
         - 'config:field.storage.user.field_first_name'
         - 'config:field.storage.user.field_last_name'
         - 'config:field.storage.user.field_user_picture'
@@ -1635,7 +1755,8 @@ display:
         header: false
         arguments: false
         relationships: false
-      path: organizers
+        pager: false
+      path: program/presenters
       css_class: 'attendee_display attendeepicture_display'
       fields:
         field_user_picture:
@@ -1682,10 +1803,10 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: '<img src="/themes/custom/twentyseventeen/images/GovCon2017_UserProfileImage.png" alt="Default Avatar">'
           hide_empty: false
           empty_zero: false
-          hide_alter_empty: true
+          hide_alter_empty: false
           click_sort_column: target_id
           type: image
           settings:
@@ -1785,7 +1906,7 @@ display:
             more_link_text: ''
             more_link_path: ''
             strip_tags: false
-            trim: true
+            trim: false
             preserve_tags: ''
             html: false
           element_type: ''
@@ -1898,7 +2019,7 @@ display:
             more_link_text: ''
             more_link_path: ''
             strip_tags: false
-            trim: true
+            trim: false
             preserve_tags: ''
             html: false
           element_type: ''
@@ -2011,7 +2132,7 @@ display:
             more_link_text: ''
             more_link_path: ''
             strip_tags: false
-            trim: true
+            trim: false
             preserve_tags: ''
             html: false
           element_type: ''
@@ -2631,16 +2752,940 @@ display:
           entity_type: user
           entity_field: uid
           plugin_id: standard
+      menu:
+        type: normal
+        title: Presenters
+        description: ''
+        expanded: false
+        parent: 'menu_link_content:cfde32b4-ff81-4a70-a608-5faf124c12ee'
+        weight: 6
+        context: '0'
+        menu_name: main
+      pager:
+        type: infinite_scroll
+        options:
+          items_per_page: 20
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          views_infinite_scroll:
+            button_text: 'Load More'
+            automatically_load_content: true
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - url.query_args
         - user
       tags:
         - 'config:field.storage.node.field_session_co_presenter_s_'
         - 'config:field.storage.user.field_company'
+        - 'config:field.storage.user.field_first_name'
+        - 'config:field.storage.user.field_last_name'
+        - 'config:field.storage.user.field_user_picture'
+  page_4:
+    display_plugin: page
+    id: page_4
+    display_title: Volunteers
+    position: 2
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: Volunteers
+      defaults:
+        title: false
+        css_class: false
+        fields: false
+        filters: false
+        filter_groups: false
+        exposed_form: false
+        header: false
+        pager: false
+      path: get-involved/volunteers
+      css_class: 'attendee_display attendeepicture_display'
+      fields:
+        field_user_picture:
+          id: field_user_picture
+          table: user__field_user_picture
+          field: field_user_picture
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: '<img src="/themes/custom/twentyseventeen/images/GovCon2017_UserProfileImage.png" alt="Default Avatar">'
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: user_profile_image
+            image_link: content
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        webform_submission_value:
+          id: webform_submission_value
+          table: webform_submission_field_registration_first_name
+          field: webform_submission_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 140
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          webform_element_format: value
+          plugin_id: webform_submission_field
+        field_first_name:
+          id: field_first_name
+          table: user__field_first_name
+          field: field_first_name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 140
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        webform_submission_value_1:
+          id: webform_submission_value_1
+          table: webform_submission_field_registration_last_name
+          field: webform_submission_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          webform_element_format: value
+          plugin_id: webform_submission_field
+        field_last_name:
+          id: field_last_name
+          table: user__field_last_name
+          field: field_last_name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 60
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        webform_submission_value_2:
+          id: webform_submission_value_2
+          table: webform_submission_field_registration_company_name
+          field: webform_submission_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 255
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          webform_element_format: value
+          plugin_id: webform_submission_field
+        field_company:
+          id: field_company
+          table: user__field_company
+          field: field_company
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 60
+            word_boundary: false
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        sid:
+          id: sid
+          table: webform_submission
+          field: sid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
+        field_conference_role:
+          id: field_conference_role
+          table: user__field_conference_role
+          field: field_conference_role
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        webform_id:
+          id: webform_id
+          table: webform_submission
+          field: webform_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            registration: registration
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+            argument: null
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: webform_submission
+          entity_field: webform_id
+          plugin_id: bundle
+        webform_submission_value:
+          id: webform_submission_value
+          table: webform_submission_field_registration_show_on_attendee_listing_page
+          field: webform_submission_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: webform_submission_field_filter
+        field_first_name_value:
+          id: field_first_name_value
+          table: user__field_first_name
+          field: field_first_name_value
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_first_name_value_op
+            label: 'First Name'
+            description: ''
+            use_operator: false
+            operator: field_first_name_value_op
+            identifier: field_first_name_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              page_creator: '0'
+              layout_manager: '0'
+              page_reviewer: '0'
+              landing_page_creator: '0'
+              landing_page_reviewer: '0'
+              media_creator: '0'
+              media_manager: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        field_last_name_value:
+          id: field_last_name_value
+          table: user__field_last_name
+          field: field_last_name_value
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_last_name_value_op
+            label: 'Last Name'
+            description: ''
+            use_operator: false
+            operator: field_last_name_value_op
+            identifier: field_last_name_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              page_creator: '0'
+              layout_manager: '0'
+              page_reviewer: '0'
+              landing_page_creator: '0'
+              landing_page_reviewer: '0'
+              media_creator: '0'
+              media_manager: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        field_company_value:
+          id: field_company_value
+          table: user__field_company
+          field: field_company_value
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_company_value_op
+            label: Organization
+            description: ''
+            use_operator: false
+            operator: field_company_value_op
+            identifier: field_company_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              page_creator: '0'
+              layout_manager: '0'
+              page_reviewer: '0'
+              landing_page_creator: '0'
+              landing_page_reviewer: '0'
+              media_creator: '0'
+              media_manager: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        field_conference_role_target_id:
+          id: field_conference_role_target_id
+          table: user__field_conference_role
+          field: field_conference_role_target_id
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            106: 106
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: conference_role
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      exposed_form:
+        type: bef
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+          bef:
+            general:
+              allow_secondary: false
+              secondary_label: 'Advanced options'
+              autosubmit: false
+              autosubmit_hide: false
+            webform_submission_value_1:
+              bef_format: default
+              more_options:
+                is_secondary: false
+                rewrite:
+                  filter_rewrite_values: ''
+      exposed_block: true
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content: 'Here''s the volunteer team that help makes Drupal GovCon happen. Drupal is all about community. Interested in joining to help out? New volunteers are always <a href="/contact">welcome</a>.'
+          plugin_id: text_custom
+      menu:
+        type: normal
+        title: Volunteers
+        description: ''
+        expanded: false
+        parent: 'menu_link_content:f0567892-778c-4181-bce3-a9f634ee5703'
+        weight: 6
+        context: '0'
+        menu_name: main
+      pager:
+        type: infinite_scroll
+        options:
+          items_per_page: 20
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          views_infinite_scroll:
+            button_text: 'Load More'
+            automatically_load_content: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+      tags:
+        - 'config:field.storage.user.field_company'
+        - 'config:field.storage.user.field_conference_role'
         - 'config:field.storage.user.field_first_name'
         - 'config:field.storage.user.field_last_name'
         - 'config:field.storage.user.field_user_picture'

--- a/docroot/themes/custom/twentyseventeen/sass/base/elements/_elements.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/base/elements/_elements.scss
@@ -18,6 +18,11 @@ body {
   /* Leave space for footer */
   position: relative;
   padding-bottom: 350px;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+  -moz-word-break: normal;
+  -moz-hyphens: auto;
 }
 // Base Headings
 //

--- a/docroot/themes/custom/twentyseventeen/sass/base/form/_form.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/base/form/_form.scss
@@ -235,7 +235,7 @@ input[type="url"][disabled] {
 select {
   appearance: none;
   color: rgba(255,255,255,1);
-  font-size: 1.2em;
+  font-size: 0.875em;
   background: rgba(0,62,106,1) url('../images/GovCon-DownArrow-SM-Rev.svg') 96% center no-repeat;
   background-size: 1em;
   border: 1px solid rgba(0,62,106,1);
@@ -256,10 +256,10 @@ input[type=submit] {
   appearance: none;
   color: rgba(255,255,255,1);
   background: rgba(0,62,106,1);
-  font-size: 1.2em;
+  font-size: 0.875em;
   background-size: 1em;
   border: 1px solid rgba(0,62,106,1);
-  padding: 0.25em 0.5em 0.25em 0.5em;
+  padding: 0.5em 0.75em 0.5em 0.75em;
   border-radius: 0.25em;
 }
 

--- a/docroot/themes/custom/twentyseventeen/sass/components/attendee-display/_attendeedisplay.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/attendee-display/_attendeedisplay.scss
@@ -24,7 +24,7 @@
 }
 
 .attendee-display .view-filters form#views-exposed-form-attendee-displays-page-1.views-exposed-form.bef-exposed-form div.form--inline.clearfix div#edit-actions.form-actions.js-form-wrapper.form-wrapper {
-	bottom: -1.4em;
+	bottom: -1.5em;
 }
 
 .attendee-names .view-content {
@@ -116,6 +116,38 @@
 	font-style: italic;
 }
 
+// Pager Styling
+.attendee-display.attendee-names nav.pager {
+	text-align: center;
+	margin-top: 2em;
+}
+
+.attendee-display.attendee-names nav.pager ul {
+	padding-left: 0;
+	list-style-type: none;
+	font-weight: 600;
+}
+
+.attendee-display.attendee-names nav.pager ul li {
+	display: inline-block;
+	padding: 0 0.25em;
+}
+
+.attendee-display.attendee-names nav.pager ul li a:link,
+.attendee-display.attendee-names nav.pager ul li a:visited,
+.attendee-display.attendee-names nav.pager ul li.pager__item--ellipsis {
+	color: rgba($green, 0.6);
+	text-decoration: none;
+}
+
+.attendee-display.attendee-names nav.pager ul li a:hover {
+	color: rgba($green, 1);
+}
+
+.attendee-display.attendee-names nav.pager ul li.pager__item.is-active a:link,
+.attendee-display.attendee-names nav.pager ul li.pager__item.is-active a:visited {
+	color: $blu;
+}
 
 
 

--- a/docroot/themes/custom/twentyseventeen/sass/components/attendee-display/_attendeedisplay.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/attendee-display/_attendeedisplay.scss
@@ -12,6 +12,8 @@
 
 }
 
+
+// Search form styling
 .attendee-display .view-filters {
 	padding: 2em 0;
 }
@@ -23,8 +25,21 @@
 	padding-right: 2em;
 }
 
+.attendee-display .view-filters .views-exposed-form.bef-exposed-form div.form--inline.clearfix div.form-item.js-form-type-textfield input {
+	//margin-bottom: 0.25em;
+}
+
 .attendee-display .view-filters form#views-exposed-form-attendee-displays-page-1.views-exposed-form.bef-exposed-form div.form--inline.clearfix div#edit-actions.form-actions.js-form-wrapper.form-wrapper {
 	bottom: -1.5em;
+	position: inherit;
+}
+
+.attendee-display .view-filters input#edit-submit-attendee-displays.button.js-form-submit.form-submit {
+	margin: 1.75em 1em 1em 0;
+}
+
+.attendee-display .view-filters .description {
+	font-style: italic;
 }
 
 .attendee-names .view-content {
@@ -160,6 +175,8 @@
 .attendee-display.attendee-names nav.pager ul li.pager__item.is-active a:link {
 	background: $green;
 }
+
+
 
 
 

--- a/docroot/themes/custom/twentyseventeen/sass/components/attendee-display/_attendeedisplay.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/attendee-display/_attendeedisplay.scss
@@ -119,7 +119,7 @@
 // Pager Styling
 .attendee-display.attendee-names nav.pager {
 	text-align: center;
-	margin-top: 2em;
+	margin: 2em 0 1em 0;
 }
 
 .attendee-display.attendee-names nav.pager ul {
@@ -130,23 +130,35 @@
 
 .attendee-display.attendee-names nav.pager ul li {
 	display: inline-block;
-	padding: 0 0.25em;
+	//padding: 0.25em 0.5em;
+	//background: rgba($green, 0.2);
 }
 
 .attendee-display.attendee-names nav.pager ul li a:link,
 .attendee-display.attendee-names nav.pager ul li a:visited,
 .attendee-display.attendee-names nav.pager ul li.pager__item--ellipsis {
-	color: rgba($green, 0.6);
+	color: rgba($green, 0.75);
 	text-decoration: none;
+	padding: 0.25em 0.5em;
+	background: rgba($green, 0.2);
+}
+
+.attendee-display.attendee-names nav.pager ul li.pager__item--ellipsis {
+	background: none;
 }
 
 .attendee-display.attendee-names nav.pager ul li a:hover {
-	color: rgba($green, 1);
+	color: $wht;
+	background: rgba($green, 1);
 }
 
 .attendee-display.attendee-names nav.pager ul li.pager__item.is-active a:link,
 .attendee-display.attendee-names nav.pager ul li.pager__item.is-active a:visited {
-	color: $blu;
+	color: $wht;
+}
+
+.attendee-display.attendee-names nav.pager ul li.pager__item.is-active a:link {
+	background: $green;
 }
 
 

--- a/docroot/themes/custom/twentyseventeen/sass/components/schedule/_schedule.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/schedule/_schedule.scss
@@ -252,13 +252,12 @@ div#edit-actions.form-actions.js-form-wrapper.form-wrapper {
 
 input#edit-submit-sessions-schedule {
 	padding: 0.25em 0.5em 0.125em 0.5em;
-	font-size: 1.2em;
+	font-size: 0.875em;
 	line-height: 1.4;
 }
 
 #edit-actions.form-actions.js-form-wrapper.form-wrapper {
-	display: inline-block;
-	position: absolute;
+	//bottom: -1em;
 	bottom: -0.6em;
 }
 

--- a/docroot/themes/custom/twentyseventeen/sass/components/userprofile/_userprofile.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/userprofile/_userprofile.scss
@@ -62,7 +62,7 @@
 
 
 .user_profile_page {
-	overflow: scroll;
+	//overflow: scroll;
 }
 
 .bio_photo {

--- a/docroot/themes/custom/twentyseventeen/sass/components/userprofile/_userprofile.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/userprofile/_userprofile.scss
@@ -63,6 +63,11 @@
 
 .user_profile_page {
 	//overflow: scroll;
+	overflow-wrap: break-word;
+  	word-wrap: break-word;
+  	word-break: break-word;
+	-moz-word-break: normal;
+	-moz-hyphens: auto;
 }
 
 .bio_photo {

--- a/docroot/themes/custom/twentyseventeen/sass/components/userprofile/_userprofile.scss
+++ b/docroot/themes/custom/twentyseventeen/sass/components/userprofile/_userprofile.scss
@@ -62,12 +62,6 @@
 
 
 .user_profile_page {
-	//overflow: scroll;
-	overflow-wrap: break-word;
-  	word-wrap: break-word;
-  	word-break: break-word;
-	-moz-word-break: normal;
-	-moz-hyphens: auto;
 }
 
 .bio_photo {


### PR DESCRIPTION
This branch includes displays for users in the following categories:
Conference Attendees
Presenters
Organizers
Volunteers

In order to do this, a new taxonomy was created, as well as adding a field to the user profile to allow organizers to categorize what conference roles a user may have.

Although it appears that there were monumental changes, many of the configuration files here that seem out of place were changed due to display weighting being affected by the addition of links to navigation for these user displays.

Also, this issue takes care of changes requested in [this issue](https://github.com/Drupal4Gov/Drupal-GovCon-2017/issues/499)