### PR TITLE
DGC-215: Fixing padding of table elements to better match the mock.

### DIFF
--- a/docroot/themes/custom/twentyeighteen/sass/base/_base.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/base/_base.scss
@@ -173,7 +173,6 @@ table {
   tbody {
     background-color: $textarea;
     color: $teal;
-    text-align: center;
   }
 
   td {


### PR DESCRIPTION
Fixes the padding on the table elements per Kat's comments on https://drupal4gov.atlassian.net/browse/DGC-215.