### PR TITLE
DGC-244: Removing unnecssary arialabelledby id on navigation.

### DIFF
--- a/docroot/themes/custom/twentyeighteen/templates/blocks/block--system-menu-block.html.twig
+++ b/docroot/themes/custom/twentyeighteen/templates/blocks/block--system-menu-block.html.twig
@@ -1,0 +1,58 @@
+{#
+/**
+ * @file
+ * Theme override for a menu block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - module: The module that provided this block plugin.
+ *   - cache: The cache settings.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: HTML attributes for the containing element.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: HTML attributes for the title element.
+ * - content_attributes: HTML attributes for the content element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * Headings should be used on navigation menus that consistently appear on
+ * multiple pages. When this menu block's label is configured to not be
+ * displayed, it is automatically made invisible using the 'visually-hidden' CSS
+ * class, which still keeps it visible for screen-readers and assistive
+ * technology. Headings allow screen-reader and keyboard only users to navigate
+ * to or skip the links.
+ * See http://juicystudio.com/article/screen-readers-display-none.php and
+ * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ */
+#}
+{% set classes = [
+'block',
+'block-menu',
+'navigation',
+'block-system-menublock',
+'menu--' ~ derivative_plugin_id|clean_class,
+] %}
+
+{% set heading_id = attributes.id ~ '-menu'|clean_id %}
+
+<nav role="navigation" {{ attributes.addClass(classes)|without('role') }}>
+  {# The label has been removed from this template per WCAG2AA.Principle1.Guideline1_3.1_3_1_A.G141 #}
+  {# Once a patch for https://www.drupal.org/project/drupal/issues/2614950 gets added to core, we can readdress this #}
+  {% if configuration.label_display %}
+    {{ title_prefix }}
+      <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+    {{ title_suffix }}
+  {% endif %}
+
+  {# Menu. #}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</nav>


### PR DESCRIPTION
https://drupal4gov.atlassian.net/browse/DGC-244