### PR TITLE
DGC-321 Schedule Contrast

### DIFF
--- a/docroot/themes/custom/twentyeighteen/sass/_config.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/_config.scss
@@ -18,17 +18,19 @@ $light-gold: rgba($gold, 0.4);
 $light-yellow: rgba($gold, 0.2);
 $pale-yellow: rgb(255, 248, 204);
 $pale-blue: rgb(154, 184, 188);
+$light-teal: rgb(114, 156, 162);
 
 // theme colors
 $teal: rgb(54, 114, 122);
 $dark-teal: rgb(43, 91, 98);
+$darker-teal: rgb(38, 74, 79);
 $sienna: rgb(142, 47, 15);
 $orange: rgb(255, 157, 1);
 $dark-gray: rgb(80, 80, 80);
 
 // Utility color variables ///////////////
 $heading: $teal;
-$link: $teal;
+$link: $dark-teal;
 $textarea: rgba(255, 253, 242, 1);
 $textarea-focus: rgba(128, 188, 250, 1);
 $legend: rgba(54, 114, 122, 0.75);

--- a/docroot/themes/custom/twentyeighteen/sass/base/_base.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/base/_base.scss
@@ -58,7 +58,7 @@ h5,
 h6 {
   text-rendering: optimizeLegibility;
   font-weight: 700;
-  color: $teal;
+  color: $dark-teal;
 }
 
 h1 {

--- a/docroot/themes/custom/twentyeighteen/sass/base/_form.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/base/_form.scss
@@ -136,7 +136,10 @@ input[type="checkbox"]:disabled + label::before {
 
 select {
   -webkit-appearance: none;
+  -moz-appearance: none;
   padding: 0.5em 2.25em 0.5em 1em;
+  border: none;
+  border-radius: 0.25em;
   box-sizing: border-box;
   width: 100%;
   background: $teal url(../images/DownArrow-Rev.svg) 94% center no-repeat;

--- a/docroot/themes/custom/twentyeighteen/sass/base/_form.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/base/_form.scss
@@ -136,7 +136,7 @@ input[type="checkbox"]:disabled + label::before {
 
 select {
   -webkit-appearance: none;
-  -moz-appearance: none;
+  -moz-appearance: none; // Removes Firefox default styling
   padding: 0.5em 2.25em 0.5em 1em;
   border: none;
   border-radius: 0.25em;

--- a/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
@@ -60,8 +60,8 @@
     border-bottom: 1px solid $gold;
 
     &:nth-child(odd) {
-      //background: rgba($gold, 0.1);
-      background: rgba($white, 0.5);
+      background: rgba($gold, 0.1);
+      background: rgba(255, 255, 230, 0.8);
     }
   }
 

--- a/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
@@ -62,7 +62,7 @@
     border-bottom: 1px solid $gold;
 
     &:nth-child(odd) {
-      background: rgba($white, 0.5);
+      background: rgba(255, 255, 230, 0.8);
     }
   }
 

--- a/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
@@ -10,18 +10,18 @@
   }
 
   a {
-    color: $white;
+    color: $darker-teal;
     padding: 0.5em 0.75em;
-    background-color: $light-teal;
+    background-color: rgba($light-teal, 0.35);
     text-transform: uppercase;
     text-decoration: none;
     border-radius: 0.25em 0.25em 0 0;
     font-size: 0.875em;
-    letter-spacing: 0.02em;
+    letter-spacing: 0.04em;
 
     &.is-active {
       background-color: $teal;
-      font-weight: 600;
+      color: $white;
       letter-spacing: 0.04em;
     }
   }

--- a/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
@@ -12,7 +12,7 @@
   a {
     color: $white;
     padding: 0.5em 0.75em;
-    background-color: $pale-blue;
+    background-color: $light-teal;
     text-transform: uppercase;
     text-decoration: none;
     border-radius: 0.25em 0.25em 0 0;
@@ -21,6 +21,8 @@
 
     &.is-active {
       background-color: $teal;
+      font-weight: 600;
+      letter-spacing: 0.04em;
     }
   }
 }
@@ -33,9 +35,9 @@
     padding: 0.25em 0.5em;
     text-transform: uppercase;
     background-color: $teal;
-    color: rgb(215, 227, 228);
+    color: rgba($white, 0.9);
     font-size: 1em;
-    letter-spacing: 0.02em;
+    letter-spacing: 0.03em;
     font-weight: 700;
   }
 
@@ -60,7 +62,7 @@
     border-bottom: 1px solid $gold;
 
     &:nth-child(odd) {
-      background: rgba($gold, 0.1);
+      //background: rgba($gold, 0.1);
       background: rgba(255, 255, 230, 0.8);
     }
   }

--- a/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
@@ -62,8 +62,7 @@
     border-bottom: 1px solid $gold;
 
     &:nth-child(odd) {
-      //background: rgba($gold, 0.1);
-      background: rgba(255, 255, 230, 0.8);
+      background: rgba($white, 0.5);
     }
   }
 

--- a/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
@@ -12,7 +12,11 @@
   a {
     color: $darker-teal;
     padding: 0.5em 0.75em;
+<<<<<<< HEAD
     background-color: rgba($light-teal, 0.35);
+=======
+    background-color: $light-teal;
+>>>>>>> DGC-321: Contrast issues resolved, also default select styling in Firefox removed.
     text-transform: uppercase;
     text-decoration: none;
     border-radius: 0.25em 0.25em 0 0;
@@ -21,7 +25,11 @@
 
     &.is-active {
       background-color: $teal;
+<<<<<<< HEAD
       color: $white;
+=======
+      font-weight: 600;
+>>>>>>> DGC-321: Contrast issues resolved, also default select styling in Firefox removed.
       letter-spacing: 0.04em;
     }
   }

--- a/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
@@ -60,7 +60,8 @@
     border-bottom: 1px solid $gold;
 
     &:nth-child(odd) {
-      background: rgba($gold, 0.1);
+      //background: rgba($gold, 0.1);
+      background: rgba($white, 0.5);
     }
   }
 

--- a/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
@@ -12,7 +12,7 @@
   a {
     color: $darker-teal;
     padding: 0.5em 0.75em;
-    background-color: rgba($light-teal, 0.35);
+    background-color: rgba($light-teal, 0.25);
     text-transform: uppercase;
     text-decoration: none;
     border-radius: 0.25em 0.25em 0 0;

--- a/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
@@ -13,10 +13,14 @@
     color: $darker-teal;
     padding: 0.5em 0.75em;
 <<<<<<< HEAD
+<<<<<<< HEAD
     background-color: rgba($light-teal, 0.35);
 =======
     background-color: $light-teal;
 >>>>>>> DGC-321: Contrast issues resolved, also default select styling in Firefox removed.
+=======
+    background-color: rgba($light-teal, 0.35);
+>>>>>>> DGC-321: Contrast ratio fixed on all elements, passes AA now.
     text-transform: uppercase;
     text-decoration: none;
     border-radius: 0.25em 0.25em 0 0;
@@ -25,11 +29,8 @@
 
     &.is-active {
       background-color: $teal;
-<<<<<<< HEAD
-      color: $white;
-=======
       font-weight: 600;
->>>>>>> DGC-321: Contrast issues resolved, also default select styling in Firefox removed.
+      color: $white;
       letter-spacing: 0.04em;
     }
   }

--- a/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
+++ b/docroot/themes/custom/twentyeighteen/sass/components/views/_schedule.scss
@@ -12,15 +12,7 @@
   a {
     color: $darker-teal;
     padding: 0.5em 0.75em;
-<<<<<<< HEAD
-<<<<<<< HEAD
     background-color: rgba($light-teal, 0.35);
-=======
-    background-color: $light-teal;
->>>>>>> DGC-321: Contrast issues resolved, also default select styling in Firefox removed.
-=======
-    background-color: rgba($light-teal, 0.35);
->>>>>>> DGC-321: Contrast ratio fixed on all elements, passes AA now.
     text-transform: uppercase;
     text-decoration: none;
     border-radius: 0.25em 0.25em 0 0;


### PR DESCRIPTION
Schedule contrast has been fixed, passes AA now.

This was checked for:

- Schedule Teaser (all elements)
- Schedule Day Tabs

In addition, select default arrow appearance in Firefox as also addressed.