### PR TITLE
DGC-000: Updated post-provision.sh to .php.

### DIFF
--- a/box/config.yml
+++ b/box/config.yml
@@ -79,4 +79,4 @@ php_xdebug_remote_port: "9000"
 php_memory_limit: "1024M"
 
 post_provision_scripts:
-  - "../../../acquia/blt/scripts/drupal-vm/post-provision.sh"
+  - "../../../acquia/blt/scripts/drupal-vm/post-provision.php"


### PR DESCRIPTION
When provisioning a new VM, the process fails because the DrupalVM is expecting to find `vendor/acquia/blt/scripts/drupal-vm/post-provision.sh` but can not because the file is now `post-provision.php`.

This PR corrects `box/config.yml` so that it uses the right file name.