### PR TITLE
DGC-779: Updates to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If you have, you will want to check this list carefully, to be sure it only cove
 
 ### CLI Method – Using Your Local
 * **First, make sure your local fork is up-to-date** following the instructions under **Working with BLT** above.
-* Create a new issue on the project [Jira board](https://drupal4gov.atlassian.net/secure/RapidBoard.jspa?projectKey=DGC&rapidView=3).
+* Create a new issue on the project [Jira board](https://drupal4gov.atlassian.net).
 * Create a new issue on the project repository above (Issues > New Issue), create an issue branch on your local site (following the instructions under Getting Started above).
 * Unzip the configuration exports you made, and place these files in the config/default folder.
 * Carefully review changes to the .yml files by using `git diff`.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ $  git push --set-upstream origin DGC-XXX
 * Create a new Pull Request that mentions the original ticket in the body (#DGC-XXX)
 * Ensure the build passes
 
+## Configuration Changes
+When making configuration changes to the production site, if these changes are not checked in, they will be overwritten on the next deploy!
+
 ## Resources
 
 * JIRA - https://drupal4gov.atlassian.net

--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ If you have, you will want to check this list carefully, to be sure it only cove
 * When at [Synchronize](https://www.drupalgovcon.org/admin/config/development/configuration), go to the Export tab, where you can export all changes using **Full archive**. Tapping the **Export** button will download an archive of these changes to your computer.
 * Follow either following method to add your changes:
 
-### GUI Method - No Local Codebase Rqquired
-* Create a new issue on the project repository above (Issues > New Issue)
+### GUI Method - No Local Codebase Required
+* Create a new issue on the project [Jira board](https://drupal4gov.atlassian.net/secure/RapidBoard.jspa?projectKey=DGC&rapidView=3).
+* Open a corresponding ticket on GitHub repository above (Issues > New Issue), create an issue branch on your local site (following the instructions under Getting Started above).
 * Unzip the configuration exports you made, and drag these files into the config/default folder on your new issue's page.
 * Carefully review your changes to the .yml files by using the Compare tab.
 * Commit the .yml files that represent the changes you made to configuration on the production site.
@@ -114,6 +115,8 @@ If you have, you will want to check this list carefully, to be sure it only cove
 
 
 ### CLI Method – Using Your Local
+* **First, make sure your local fork is up-to-date** following the instructions under **Working with BLT** above.
+* Create a new issue on the project [Jira board](https://drupal4gov.atlassian.net/secure/RapidBoard.jspa?projectKey=DGC&rapidView=3).
 * Create a new issue on the project repository above (Issues > New Issue), create an issue branch on your local site (following the instructions under Getting Started above).
 * Unzip the configuration exports you made, and place these files in the config/default folder.
 * Carefully review changes to the .yml files by using `git diff`.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you have, you will want to check this list carefully, to be sure it only cove
 * Open a corresponding ticket on GitHub repository above (Issues > New Issue), create an issue branch on your local site (following the instructions under Getting Started above).
 * Unzip the configuration exports you made, and drag these files into the config/default folder on your new issue's page.
 * Carefully review your changes to the .yml files by using the Compare tab.
-* Commit the .yml files that represent the changes you made to configuration on the production site.
+* Add, commit, and push your changes to the production configuration, then open a pull request. **This step assumes that you already have a [fork](https://help.github.com/en/articles/fork-a-repo) of the codebase locally**.
 * Create a pull request (When you commit your changes, you should see this button on the main project repository page).
 * Notify the #website team on Slack.
 

--- a/README.md
+++ b/README.md
@@ -98,17 +98,17 @@ When making configuration changes to the production site—and this includes men
 
 If in doubt whether you have made configuration changes, go to [Synchronize](https://www.drupalgovcon.org/admin/config/development/configuration), where any configurations you have updated will be listed.
 
-If you have, you will want to check this list carefully, to be sure it only covers the changes you want to add. When you have checked these over, there are two ways you can add these changes:
+If you have, you will want to check this list carefully, to be sure it only covers the changes you want to add. When you have checked these over, here's how you can add these changes:
 
-### GUI (Non-Code) Method
+### Exporting Your Changes
 * When at [Synchronize](https://www.drupalgovcon.org/admin/config/development/configuration), go to the Export tab, where you can export all changes using **Full archive**. Tapping the **Export** button will download an archive of these changes to your computer.
-* Create a new issue on the project repository above (Issues > New Issue), describe the changes, and attach the archive.
-* Notify the #website team on Slack.
 
-### CLI (Code) Method
-* Open a new issue ticket, create an issue branch (following the instructions under Getting Started above).
-* Export your configuration changes using `drush cex`, check the listed changes. If they are correct, approve them.
-* Add, commit, and push your changes, then open a pull request.
+
+### Creating an Issue
+* Create a new issue on the project repository above (Issues > New Issue), create an issue branch on your local site (following the instructions under Getting Started above).
+* Unzip the configuration exports you made, and place these files in the config/default folder.
+* Carefully review changes to the .yml files by using `git diff`.
+* Add, commit, and push your changes to the production configuration, then open a pull request.
 * Notify the #website team on Slack.
 
 If in doubt, please reach out to a member of the Web team!

--- a/README.md
+++ b/README.md
@@ -101,8 +101,17 @@ If in doubt whether you have made configuration changes, go to [Synchronize](htt
 If you have, you will want to check this list carefully, to be sure it only covers the changes you want to add. When you have checked these over, there are two ways you can add these changes:
 
 ### GUI (Non-Code) Method
-When at [Synchronize](https://www.drupalgovcon.org/admin/config/development/configuration), go to the Export tab, where you can export all changes using **Full archive**. Tapping the **Export** button will download an archive of these changes to your computer.
+* When at [Synchronize](https://www.drupalgovcon.org/admin/config/development/configuration), go to the Export tab, where you can export all changes using **Full archive**. Tapping the **Export** button will download an archive of these changes to your computer.
+* Create a new issue on the project repository above (Issues > New Issue), describe the changes, and attach the archive.
+* Notify the #website team on Slack.
 
+### CLI (Code) Method
+* Open a new issue ticket, create an issue branch
+* Export your configuration changes using `drush cex`, check the listed changes. If they are correct, approve them.
+* Add, commit, and push your changes, then open a pull request.
+* Notify the #website team on Slack.
+
+If in doubt, please reach out to a member of the Web team!
 
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $  git push --set-upstream origin DGC-XXX
 * Create a new Pull Request that mentions the original ticket in the body (#DGC-XXX)
 * Ensure the build passes
 
-## Configuration Changes
+## Configuration Changes-Use Only in Dire Situations
 When making configuration changes to the production site—and this includes menu, block, and view updates, **if these are not checked in, they will be overwritten on the next deploy!**
 
 If in doubt whether you have made configuration changes, go to [Synchronize](https://www.drupalgovcon.org/admin/config/development/configuration), where any configurations you have updated will be listed.
@@ -102,9 +102,18 @@ If you have, you will want to check this list carefully, to be sure it only cove
 
 ### Exporting Your Changes
 * When at [Synchronize](https://www.drupalgovcon.org/admin/config/development/configuration), go to the Export tab, where you can export all changes using **Full archive**. Tapping the **Export** button will download an archive of these changes to your computer.
+* Follow either following method to add your changes:
+
+### GUI Method - No Local Codebase Rqquired
+* Create a new issue on the project repository above (Issues > New Issue)
+* Unzip the configuration exports you made, and drag these files into the config/default folder on your new issue's page.
+* Carefully review your changes to the .yml files by using the Compare tab.
+* Commit the .yml files that represent the changes you made to configuration on the production site.
+* Create a pull request (When you commit your changes, you should see this button on the main project repository page).
+* Notify the #website team on Slack.
 
 
-### Creating an Issue
+### CLI Method – Using Your Local
 * Create a new issue on the project repository above (Issues > New Issue), create an issue branch on your local site (following the instructions under Getting Started above).
 * Unzip the configuration exports you made, and place these files in the config/default folder.
 * Carefully review changes to the .yml files by using `git diff`.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you have, you will want to check this list carefully, to be sure it only cove
 * Notify the #website team on Slack.
 
 ### CLI (Code) Method
-* Open a new issue ticket, create an issue branch
+* Open a new issue ticket, create an issue branch (following the instructions under Getting Started above).
 * Export your configuration changes using `drush cex`, check the listed changes. If they are correct, approve them.
 * Add, commit, and push your changes, then open a pull request.
 * Notify the #website team on Slack.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,12 @@ When making configuration changes to the production site—and this includes men
 
 If in doubt whether you have made configuration changes, go to [Synchronize](https://www.drupalgovcon.org/admin/config/development/configuration), where any configurations you have updated will be listed.
 
-If you have, you will want to check this list carefully, to be sure it only covers the changes you want to add.
+If you have, you will want to check this list carefully, to be sure it only covers the changes you want to add. When you have checked these over, there are two ways you can add these changes:
+
+### GUI (Non-Code) Method
+When at [Synchronize](https://www.drupalgovcon.org/admin/config/development/configuration), go to the Export tab, where you can export all changes using **Full archive**. Tapping the **Export** button will download an archive of these changes to your computer.
+
+
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ $  git push --set-upstream origin DGC-XXX
 * Ensure the build passes
 
 ## Configuration Changes
-When making configuration changes to the production site, if these changes are not checked in, they will be overwritten on the next deploy!
+When making configuration changes to the production site—and this includes menu, block, and view updates, **if these are not checked in, they will be overwritten on the next deploy!**
+
+If in doubt whether you have made configuration changes, go to [Synchronize](https://www.drupalgovcon.org/admin/config/development/configuration), where any configurations you have updated will be listed.
+
+If you have, you will want to check this list carefully, to be sure it only covers the changes you want to add.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ If you have, you will want to check this list carefully, to be sure it only cove
 
 ### GUI Method - No Local Codebase Required
 * Create a new issue on the project [Jira board](https://drupal4gov.atlassian.net/secure/RapidBoard.jspa?projectKey=DGC&rapidView=3).
+* Pull the latest updates from the upstream master.
 * Open a corresponding ticket on GitHub repository above (Issues > New Issue), create an issue branch on your local site (following the instructions under Getting Started above).
 * Unzip the configuration exports you made, and drag these files into the config/default folder on your new issue's page.
 * Carefully review your changes to the .yml files by using the Compare tab.


### PR DESCRIPTION
Based on an issue experienced in the past week where configuration changes made by a site admin were reverted on deploy, because they weren't aware of how configuration changes are managed in Drupal 8, a section has been added to the repository's Readme file to address this.

Please check this for clarity and accuracy, and let me know if any edits are needed.