### PR TITLE
DGC-000: Disable script for older themes.

### DIFF
--- a/blt/scripts/frontend-build.sh
+++ b/blt/scripts/frontend-build.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-echo "running frontend build for twentyseventeen"
-(cd docroot/themes/custom/twentyseventeen;npm run build)
+# echo "running frontend build for twentyseventeen"
+# (cd docroot/themes/custom/twentyseventeen;npm run build)
 
-echo "running frontend build for twentyeighteen"
-(cd docroot/themes/custom/twentyeighteen;npm run build)
+# echo "running frontend build for twentyeighteen"
+# (cd docroot/themes/custom/twentyeighteen;npm run build)
 
 echo "running frontend build for twentynineteen"
 (cd docroot/themes/custom/twentynineteen;npm run build)

--- a/blt/scripts/frontend-setup.sh
+++ b/blt/scripts/frontend-setup.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-echo "running frontend setup for twentyseventeen"
-(cd docroot/themes/custom/twentyseventeen;npm run install-tools)
+# echo "running frontend setup for twentyseventeen"
+# (cd docroot/themes/custom/twentyseventeen;npm run install-tools)
 
-echo "running frontend setup for twentyeighteen"
-(cd docroot/themes/custom/twentyeighteen;npm run install-tools)
+# echo "running frontend setup for twentyeighteen"
+# (cd docroot/themes/custom/twentyeighteen;npm run install-tools)
 
 echo "running frontend setup for twentynineteen"
 (cd docroot/themes/custom/twentynineteen;npm run install-tools)


### PR DESCRIPTION
@mikemadison13 with the older shell scripts enabled compiling takes a while locally. Is there any reason to have these scripts running each time? If not can we include this PR?