### PR TITLE
DGC-10: Prevent CKEditor buttons exposed to public theme from being `color: white !important` (among other styles CKEditor buttons aren't expecting).

### DIFF
--- a/docroot/themes/custom/twentynineteen/scss/components/atoms/buttons/_buttons.scss
+++ b/docroot/themes/custom/twentynineteen/scss/components/atoms/buttons/_buttons.scss
@@ -6,7 +6,7 @@
 //
 // Style guide: atoms.buttons
 
-button,
+button:not(.ck-button),
 .btn,
 .button,
 a.button,


### PR DESCRIPTION
The `colors.$white !important;` line is what made CKEditor nearly unusable here (white on white), but instead of removing the `!important` and then having to hunt down all other uses of `button, .btn, .button, a.button, input[type="button"], input[type="reset"], input[type="submit"]` to see what might not be rendering white, I excluded `.ck-button` buttons from `button` styling, which also removed some other public-theme styling (e.g. text-shadow and text-transform) that CKE is probably not expecting.